### PR TITLE
Add getter and setter for speculativeContactDistance

### DIFF
--- a/src/main/java/com/github/stephengold/joltjni/PhysicsSettings.java
+++ b/src/main/java/com/github/stephengold/joltjni/PhysicsSettings.java
@@ -147,6 +147,31 @@ public class PhysicsSettings
     }
 
     /**
+     * Alter the speculative contact distance.
+     * (native attribute: mSpeculativeContactDistance)
+     *
+     * @param distance the desired distance (in meters, ≥0, default=0.02)
+     */
+    public void setSpeculativeContactDistance(float distance) {
+        long settingsVa = va();
+        setSpeculativeContactDistance(settingsVa, distance);
+    }
+
+    /**
+     * Return the speculative contact distance. The settings are unaffected.
+     * (native attribute: mSpeculativeContactDistance)
+     *
+     * @return the distance (in meters, ≥0)
+     */
+    @Override
+    public float getSpeculativeContactDistance() {
+        long settingsVa = va();
+        float result = getSpeculativeContactDistance(settingsVa);
+        assert result >= 0f : result;
+        return result;
+    }
+
+    /**
      * Alter the time interval before an object can fall asleep. (native
      * attribute: mTimeBeforeSleep)
      *
@@ -328,4 +353,9 @@ public class PhysicsSettings
 
     native private static void setTimeBeforeSleep(
             long settingsVa, float interval);
+
+    native private static float getSpeculativeContactDistance(long settingsVa);
+
+    native private static void setSpeculativeContactDistance(
+            long settingsVa, float distance);
 }

--- a/src/main/java/com/github/stephengold/joltjni/readonly/ConstPhysicsSettings.java
+++ b/src/main/java/com/github/stephengold/joltjni/readonly/ConstPhysicsSettings.java
@@ -89,4 +89,11 @@ public interface ConstPhysicsSettings extends ConstJoltPhysicsObject {
      * @return the interval (in seconds, &ge;0)
      */
     float getTimeBeforeSleep();
+
+    /**
+     * Return the speculative contact distance. The settings are unaffected.
+     *
+     * @return the distance (in meters, ≥0)
+     */
+    float getSpeculativeContactDistance();
 }

--- a/src/main/native/glue/ph/PhysicsSettings.cpp
+++ b/src/main/native/glue/ph/PhysicsSettings.cpp
@@ -253,3 +253,28 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_PhysicsSettings_setTi
             = reinterpret_cast<PhysicsSettings *> (settingsVa);
     pSettings->mTimeBeforeSleep = interval;
 }
+
+/*
+ * Class:     com_github_stephengold_joltjni_PhysicsSettings
+ * Method:    getSpeculativeContactDistance
+ * Signature: (J)F
+ */
+JNIEXPORT jfloat JNICALL Java_com_github_stephengold_joltjni_PhysicsSettings_getSpeculativeContactDistance
+  (JNIEnv *, jclass, jlong settingsVa) {
+    const PhysicsSettings * const pSettings
+            = reinterpret_cast<PhysicsSettings *> (settingsVa);
+    const float result = pSettings->mSpeculativeContactDistance;
+    return result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_PhysicsSettings
+ * Method:    setSpeculativeContactDistance
+ * Signature: (JF)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_PhysicsSettings_setSpeculativeContactDistance
+  (JNIEnv *, jclass, jlong settingsVa, jfloat distance) {
+    PhysicsSettings * const pSettings
+            = reinterpret_cast<PhysicsSettings *> (settingsVa);
+    pSettings->mSpeculativeContactDistance = distance;
+}


### PR DESCRIPTION
Added getter and setter for speculativeContactDistance to allow configuring how close objects can get before generating contact. This fixes issues where objects slightly penetrated each other without proper collision resolution.