### PR TITLE
Implement batch retrieval for physics body states

### DIFF
--- a/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
+++ b/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
@@ -996,9 +996,6 @@ public class PhysicsSystem extends NonCopyable {
 
     native private static long getBodyActivationListener(long systemVa);
 
-    native private static int getInactiveBodyStates(long systemVa, int bodyType,
-                                                    int[] outBodyIds, double[] outPositions, float[] outRotations);
-
     native private static long getBodyInterface(long systemVa);
 
     native private static long getBodyInterfaceNoLock(long systemVa);
@@ -1025,6 +1022,9 @@ public class PhysicsSystem extends NonCopyable {
     native private static float getGravityY(long systemVa);
 
     native private static float getGravityZ(long systemVa);
+
+    native private static int getInactiveBodyStates(long systemVa, int bodyType,
+                                                    int[] outBodyIds, double[] outPositions, float[] outRotations);
 
     native private static long getNarrowPhaseQuery(long systemVa);
 

--- a/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
+++ b/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
@@ -381,22 +381,29 @@ public class PhysicsSystem extends NonCopyable {
 
     /**
      * Retrieve the states of all bodies in the system, regardless of their
-     * activation state.
+     * activation state. For inactive bodies, velocities will be zero.
      *
      * @param outBodyIds an array to be filled with the body IDs (not null)
      * @param outPositions an array for positions (x, y, z); requires 3 elements
      * per body (not null)
      * @param outRotations an array for rotations (x, y, z, w); requires 4
      * elements per body (not null)
+     * @param outLinearVelocities an array for linear velocities (x, y, z);
+     * requires 3 elements per body (not null)
+     * @param outAngularVelocities an array for angular velocities (x, y, z);
+     * requires 3 elements per body (not null)
      * @return the number of bodies whose states were written to the arrays
      */
     public int getBodyStates(
             int[] outBodyIds,
             double[] outPositions,
-            float[] outRotations) {
+            float[] outRotations,
+            float[] outLinearVelocities,
+            float[] outAngularVelocities) {
         long systemVa = va();
         int result = getBodyStates(systemVa,
-                outBodyIds, outPositions, outRotations);
+                outBodyIds, outPositions, outRotations,
+                outLinearVelocities, outAngularVelocities);
 
         return result;
     }
@@ -1005,7 +1012,8 @@ public class PhysicsSystem extends NonCopyable {
     native private static long getBodyLockInterfaceNoLock(long systemVa);
 
     native private static int getBodyStates(long systemVa,
-                                            int[] outBodyIds, double[] outPositions, float[] outRotations);
+                                            int[] outBodyIds, double[] outPositions, float[] outRotations,
+                                            float[] outLinearVelocities, float[] outAngularVelocities);
 
     native private static long getBounds(long systemVa);
 

--- a/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
+++ b/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
@@ -331,31 +331,6 @@ public class PhysicsSystem extends NonCopyable {
     }
 
     /**
-     * Retrieve the states of all inactive bodies of a specific type.
-     *
-     * @param bodyType the type of bodies to retrieve (not null)
-     * @param outBodyIds an array to be filled with the body IDs (not null)
-     * @param outPositions an array for positions (x, y, z); requires 3 elements
-     * per body (not null)
-     * @param outRotations an array for rotations (x, y, z, w); requires 4
-     * elements per body (not null)
-     * @return the number of inactive bodies whose states were written to the
-     * arrays
-     */
-    public int getInactiveBodyStates(
-            EBodyType bodyType,
-            int[] outBodyIds,
-            double[] outPositions,
-            float[] outRotations) {
-        long systemVa = va();
-        int ordinal = bodyType.ordinal();
-        int result = getInactiveBodyStates(systemVa, ordinal,
-                outBodyIds, outPositions, outRotations);
-
-        return result;
-    }
-
-    /**
      * Access the system's {@code BodyInterface}.
      *
      * @return the pre-existing JVM object (not null)
@@ -556,6 +531,31 @@ public class PhysicsSystem extends NonCopyable {
         float y = getGravityY(systemVa);
         float z = getGravityZ(systemVa);
         Vec3 result = new Vec3(x, y, z);
+
+        return result;
+    }
+
+    /**
+     * Retrieve the states of all inactive bodies of a specific type.
+     *
+     * @param bodyType the type of bodies to retrieve (not null)
+     * @param outBodyIds an array to be filled with the body IDs (not null)
+     * @param outPositions an array for positions (x, y, z); requires 3 elements
+     * per body (not null)
+     * @param outRotations an array for rotations (x, y, z, w); requires 4
+     * elements per body (not null)
+     * @return the number of inactive bodies whose states were written to the
+     * arrays
+     */
+    public int getInactiveBodyStates(
+            EBodyType bodyType,
+            int[] outBodyIds,
+            double[] outPositions,
+            float[] outRotations) {
+        long systemVa = va();
+        int ordinal = bodyType.ordinal();
+        int result = getInactiveBodyStates(systemVa, ordinal,
+                outBodyIds, outPositions, outRotations);
 
         return result;
     }

--- a/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
+++ b/src/main/java/com/github/stephengold/joltjni/PhysicsSystem.java
@@ -266,6 +266,39 @@ public class PhysicsSystem extends NonCopyable {
     }
 
     /**
+     * Retrieve the states of all active bodies of a specific type in a single,
+     * optimized JNI call.
+     *
+     * @param bodyType the type of bodies to retrieve (not null)
+     * @param outBodyIds an array to be filled with the body IDs (not null)
+     * @param outPositions an array for positions (x, y, z); requires 3 elements
+     * per body (not null)
+     * @param outRotations an array for rotations (x, y, z, w); requires 4
+     * elements per body (not null)
+     * @param outLinearVelocities an array for linear velocities (x, y, z);
+     * requires 3 elements per body (not null)
+     * @param outAngularVelocities an array for angular velocities (x, y, z);
+     * requires 3 elements per body (not null)
+     * @return the number of active bodies whose states were written to the
+     * arrays
+     */
+    public int getActiveBodyStates(
+            EBodyType bodyType,
+            int[] outBodyIds,
+            double[] outPositions,
+            float[] outRotations,
+            float[] outLinearVelocities,
+            float[] outAngularVelocities) {
+        long systemVa = va();
+        int ordinal = bodyType.ordinal();
+        int result = getActiveBodyStates(systemVa, ordinal,
+                outBodyIds, outPositions, outRotations,
+                outLinearVelocities, outAngularVelocities);
+
+        return result;
+    }
+
+    /**
      * Enumerate all bodies to the specified variable-length vector. The system
      * is unaffected.
      *
@@ -293,6 +326,31 @@ public class PhysicsSystem extends NonCopyable {
         } else {
             result = new BodyActivationListener(listenerVa);
         }
+
+        return result;
+    }
+
+    /**
+     * Retrieve the states of all inactive bodies of a specific type.
+     *
+     * @param bodyType the type of bodies to retrieve (not null)
+     * @param outBodyIds an array to be filled with the body IDs (not null)
+     * @param outPositions an array for positions (x, y, z); requires 3 elements
+     * per body (not null)
+     * @param outRotations an array for rotations (x, y, z, w); requires 4
+     * elements per body (not null)
+     * @return the number of inactive bodies whose states were written to the
+     * arrays
+     */
+    public int getInactiveBodyStates(
+            EBodyType bodyType,
+            int[] outBodyIds,
+            double[] outPositions,
+            float[] outRotations) {
+        long systemVa = va();
+        int ordinal = bodyType.ordinal();
+        int result = getInactiveBodyStates(systemVa, ordinal,
+                outBodyIds, outPositions, outRotations);
 
         return result;
     }
@@ -342,6 +400,28 @@ public class PhysicsSystem extends NonCopyable {
         long interfaceVa = getBodyLockInterfaceNoLock(systemVa);
         BodyLockInterfaceNoLock result
                 = new BodyLockInterfaceNoLock(this, interfaceVa);
+
+        return result;
+    }
+
+    /**
+     * Retrieve the states of all bodies in the system, regardless of their
+     * activation state.
+     *
+     * @param outBodyIds an array to be filled with the body IDs (not null)
+     * @param outPositions an array for positions (x, y, z); requires 3 elements
+     * per body (not null)
+     * @param outRotations an array for rotations (x, y, z, w); requires 4
+     * elements per body (not null)
+     * @return the number of bodies whose states were written to the arrays
+     */
+    public int getBodyStates(
+            int[] outBodyIds,
+            double[] outPositions,
+            float[] outRotations) {
+        long systemVa = va();
+        int result = getBodyStates(systemVa,
+                outBodyIds, outPositions, outRotations);
 
         return result;
     }
@@ -907,9 +987,17 @@ public class PhysicsSystem extends NonCopyable {
     native private static void getActiveBodies(
             long systemVa, int ordinal, long vectorVa);
 
+
+    native private static int getActiveBodyStates(long systemVa, int bodyType,
+                                                  int[] outBodyIds, double[] outPositions, float[] outRotations,
+                                                  float[] outLinearVelocities, float[] outAngularVelocities);
+
     native private static void getBodies(long systemVa, long vectorVa);
 
     native private static long getBodyActivationListener(long systemVa);
+
+    native private static int getInactiveBodyStates(long systemVa, int bodyType,
+                                                    int[] outBodyIds, double[] outPositions, float[] outRotations);
 
     native private static long getBodyInterface(long systemVa);
 
@@ -918,6 +1006,9 @@ public class PhysicsSystem extends NonCopyable {
     native private static long getBodyLockInterface(long systemVa);
 
     native private static long getBodyLockInterfaceNoLock(long systemVa);
+
+    native private static int getBodyStates(long systemVa,
+                                            int[] outBodyIds, double[] outPositions, float[] outRotations);
 
     native private static long getBounds(long systemVa);
 


### PR DESCRIPTION
This adds new batch methods to `PhysicsSystem` for retrieving the state of multiple bodies at once (`getActiveBodyStates`, `getInactiveBodyStates`, `getBodyStates`). These methods are designed for high-performance applications by writing data directly into primitive arrays, which significantly reduces JNI overhead and GC pressure compared to iterating and calling individual getters. This provides a much more efficient pathway for synchronizing large numbers of physics objects.