### PR TITLE
solution for issue #23 (inefficient contact listeners)

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -96,6 +96,7 @@ $(N)/glue/co/Constraints.cpp \
 $(N)/glue/co/ConstraintSettings.cpp \
 $(N)/glue/co/Contact.cpp \
 $(N)/glue/co/ContactListener.cpp \
+$(N)/glue/co/ContactListenerList.cpp \
 $(N)/glue/co/ContactManifold.cpp \
 $(N)/glue/co/ContactSettings.cpp \
 $(N)/glue/co/ConvexHullBuilder.cpp \

--- a/Android.mk
+++ b/Android.mk
@@ -143,6 +143,7 @@ $(N)/glue/e/EmptyShapeSettings.cpp \
 $(N)/glue/e/EpaPenetrationDepth.cpp \
 $(N)/glue/e/ExtendedUpdateSettings.cpp \
 $(N)/glue/f/Face.cpp \
+$(N)/glue/f/FilteredContactListener.cpp \
 $(N)/glue/f/FixedConstraintSettings.cpp \
 $(N)/glue/g/GearConstraint.cpp \
 $(N)/glue/g/GearConstraintSettings.cpp \

--- a/src/main/java/com/github/stephengold/joltjni/ContactListenerList.java
+++ b/src/main/java/com/github/stephengold/joltjni/ContactListenerList.java
@@ -1,0 +1,153 @@
+/*
+Copyright (c) 2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.github.stephengold.joltjni;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A variable-length array of contact listeners.
+ * <p>
+ * When employed as a contact listener, it invokes each sub-listener in order,
+ * and the value returned by {@code OnContactValidate()} will be the one with
+ * the highest ordinal.
+ *
+ * @author Stephen Gold sgold@sonic.net
+ */
+public class ContactListenerList extends ContactListener {
+    // *************************************************************************
+    // fields
+
+    /**
+     * protect the sub-listeners from garbage collection
+     */
+    private static List<ContactListener> sublisteners = new ArrayList<>(8);
+    // *************************************************************************
+    // constructors
+
+    /**
+     * Instantiate an empty list.
+     */
+    public ContactListenerList() {
+        long listVa = createDefault();
+        setVirtualAddress(listVa, () -> free(listVa));
+    }
+    // *************************************************************************
+    // new methods exposed
+
+    /**
+     * Remove all sub-listeners.
+     */
+    public synchronized void clear() {
+        int size = size();
+        sublisteners.clear();
+
+        long listVa = va();
+        erase(listVa, 0, size);
+    }
+
+    /**
+     * Test whether the list contains one or more sub-listeners. The list is
+     * unaffected.
+     *
+     * @return {@code true} if empty, otherwise {@code false}
+     */
+    public synchronized boolean empty() {
+        boolean result = sublisteners.isEmpty();
+        return result;
+    }
+
+    /**
+     * Access the sub-listener at the specified index.
+     *
+     * @param index the index of the listener (&ge;0, &lt;size)
+     * @return the pre-existing object
+     */
+    public synchronized ContactListener get(int index) {
+        ContactListener result = sublisteners.get(index);
+        return result;
+    }
+
+    /**
+     * Append the specified listener to the end.
+     *
+     * @param listener the object to append (not {@code null})
+     */
+    public synchronized void pushBack(ContactListener listener) {
+        sublisteners.add(listener);
+
+        long listVa = va();
+        long listenerVa = listener.va();
+        pushBack(listVa, listenerVa);
+    }
+
+    /**
+     * Remove all sub-listeners equal to the argument.
+     *
+     * @param listener the listener to remove (not {@code null})
+     */
+    public synchronized void remove(ContactListener listener) {
+        int oldSize = sublisteners.size();
+        long listVa = va();
+        for (int i = oldSize - 1; i >= 0; --i) {
+            ContactListener current = sublisteners.get(i);
+            if (current.equals(listener)) {
+                sublisteners.remove(i);
+                erase(listVa, i, i + 1);
+            }
+        }
+    }
+
+    /**
+     * Count how many sub-listeners there are. The list is unaffected.
+     *
+     * @return the number of sub-listeners (&ge;0)
+     */
+    public synchronized int size() {
+        int result = sublisteners.size();
+        return result;
+    }
+
+    /**
+     * Add all the sub-listeners (in order) to a Java list.
+     *
+     * @return a new Java list
+     */
+    public synchronized List<ContactListener> toList() {
+        int size = sublisteners.size();
+        List<ContactListener> result = new ArrayList<>(size);
+        result.addAll(sublisteners);
+
+        return result;
+    }
+    // *************************************************************************
+    // native private methods
+
+    native private static long createDefault();
+
+    native private static void erase(
+            long listVa, int startIndex, int stopIndex);
+
+    native private static void free(long listVa);
+
+    native private static int pushBack(long listVa, long listenerVa);
+}

--- a/src/main/java/com/github/stephengold/joltjni/ContactListenerList.java
+++ b/src/main/java/com/github/stephengold/joltjni/ContactListenerList.java
@@ -149,5 +149,5 @@ public class ContactListenerList extends ContactListener {
 
     native private static void free(long listVa);
 
-    native private static int pushBack(long listVa, long listenerVa);
+    native private static void pushBack(long listVa, long listenerVa);
 }

--- a/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
+++ b/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
@@ -1,0 +1,296 @@
+/*
+Copyright (c) 2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.github.stephengold.joltjni;
+
+import com.github.stephengold.joltjni.enumerate.EFilterMode;
+import com.github.stephengold.joltjni.enumerate.ValidateResult;
+
+/**
+ * A customizable {@code ContactListener} with configurable filtering.
+ *
+ * @author Stephen Gold sgold@sonic.net
+ */
+public class FilteredContactListener extends ContactListener {
+    // *************************************************************************
+    // fields
+
+    /**
+     * protect the assigned {@code BodyFilter} from garbage collection
+     */
+    private BodyFilter bodyFilter;
+    /**
+     * protect the assigned {@code BroadPhaseLayerFilter} from garbage
+     * collection
+     */
+    private BroadPhaseLayerFilter bplFilter;
+    /**
+     * protect the assigned {@code ObjectLayerPairFilter} from garbage
+     * collection
+     */
+    private ObjectLayerPairFilter olpFilter;
+    // *************************************************************************
+    // constructors
+
+    /**
+     * Instantiate a listener with no filters.
+     */
+    public FilteredContactListener() {
+        long listenerVa = createDefault();
+        setVirtualAddressAsOwner(listenerVa);
+    }
+    // *************************************************************************
+    // new methods exposed
+
+    /**
+     * Access the body filter.
+     *
+     * @return the pre-existing instance, or {@code null} if none
+     */
+    public BodyFilter getBodyFilter() {
+        return bodyFilter;
+    }
+
+    /**
+     * Return the body-filter mode.
+     *
+     * @return a enum value (not {@code null})
+     */
+    public EFilterMode getBodyFilterMode() {
+        long listenerVa = va();
+        int ordinal = getBodyFilterMode(listenerVa);
+        EFilterMode result = EFilterMode.values()[ordinal];
+
+        return result;
+    }
+
+    /**
+     * Access the broadphase-layer filter
+     *
+     * @return the pre-existing instance, or {@code null} if none
+     */
+    public BroadPhaseLayerFilter getBroadPhaseLayerFilter() {
+        return bplFilter;
+    }
+
+    /**
+     * Return the broadphase-layer filter mode.
+     *
+     * @return a enum value (not {@code null})
+     */
+    public EFilterMode getBroadPhaseLayerFilterMode() {
+        long listenerVa = va();
+        int ordinal = getBroadPhaseLayerFilterMode(listenerVa);
+        EFilterMode result = EFilterMode.values()[ordinal];
+
+        return result;
+    }
+
+    /**
+     * Access the object-layer pair filter.
+     *
+     * @return the pre-existing instance, or {@code null} if none
+     */
+    public ObjectLayerPairFilter getObjectLayerPairFilter() {
+        return olpFilter;
+    }
+
+    /**
+     * Return the object-layer filter mode.
+     *
+     * @return a enum value (not {@code null})
+     */
+    public EFilterMode getObjectLayerFilterMode() {
+        long listenerVa = va();
+        int ordinal = getObjectLayerFilterMode(listenerVa);
+        EFilterMode result = EFilterMode.values()[ordinal];
+
+        return result;
+    }
+
+    /**
+     * Callback invoked (by native code) each time a new contact point is
+     * detected. Meant to be overridden.
+     *
+     * @param body1Va the virtual address of the first body in contact (not
+     * zero)
+     * @param body2Va the virtual address of the 2nd body in contact (not zero)
+     * @param manifoldVa the virtual address of the contact manifold (not zero)
+     * @param settingsVa the virtual address of the contact settings (not zero)
+     */
+    public void onContactAdded(
+            long body1Va, long body2Va, long manifoldVa, long settingsVa) {
+        // do nothing
+    }
+
+    /**
+     * Callback invoked (by native code) each time a contact is detected that
+     * was also detected during the previous update. Meant to be overridden.
+     *
+     * @param body1Va the virtual address of the first body in contact (not
+     * zero)
+     * @param body2Va the virtual address of the 2nd body in contact (not zero)
+     * @param manifoldVa the virtual address of the contact manifold (not zero)
+     * @param settingsVa the virtual address of the contact settings (not zero)
+     */
+    public void onContactPersisted(
+            long body1Va, long body2Va, long manifoldVa, long settingsVa) {
+        // do nothing
+    }
+
+    /**
+     * Callback invoked (by native code) each time a contact that was detected
+     * during the previous update is no longer detected. Meant to be overridden.
+     *
+     * @param pairVa the virtual address of the {@code SubShapeIDPair} (not
+     * zero)
+     */
+    public void onContactRemoved(long pairVa) {
+        // do nothing
+    }
+
+    /**
+     * Callback invoked (by native code) after detecting collision between a
+     * pair of bodies, but before invoking {@code onContactAdded()} and before
+     * adding the contact constraint. Meant to be overridden.
+     *
+     * @param body1Va the virtual address of the first body in contact (not
+     * zero)
+     * @param body2Va the virtual address of the 2nd body in contact (not zero)
+     * @param baseOffsetX the X component of the base offset
+     * @param baseOffsetY the Y component of the base offset
+     * @param baseOffsetZ the Z component of the base offset
+     * @param collisionResultVa the virtual address of the
+     * {@code CollideShapeResult} (not zero)
+     * @return how to the contact should be processed (an ordinal of
+     * {@code ValidateResult})
+     */
+    public int onContactValidate(long body1Va, long body2Va, double baseOffsetX,
+            double baseOffsetY, double baseOffsetZ, long collisionResultVa) {
+        int result = ValidateResult.AcceptAllContactsForThisBodyPair.ordinal();
+        return result;
+    }
+
+    /**
+     * Replace the listener's body filter.
+     *
+     * @param bodyFilter the desired filter, or {@code null} for none
+     * (default=none)
+     * @return the modified listener, for chaining
+     */
+    public FilteredContactListener setBodyFilter(BodyFilter bodyFilter) {
+        this.bodyFilter = bodyFilter;
+
+        long listenerVa = va();
+        long bodyFilterVa = bodyFilter.va();
+        setBodyFilter(listenerVa, bodyFilterVa);
+
+        return this;
+    }
+
+    /**
+     * Alter the body-filter mode.
+     *
+     * @param mode the desired mode (not {@code null}, default=Both)
+     * @return the modified listener, for chaining
+     */
+    public FilteredContactListener setBodyFilterMode(EFilterMode mode) {
+        long listenerVa = va();
+        int ordinal = mode.ordinal();
+        setBodyFilterMode(listenerVa, ordinal);
+
+        return this;
+    }
+
+    /**
+     * Replace the listener's broadphase-layer filter.
+     *
+     * @param bplFilter the desired filter, or {@code null} for none
+     * (default=none)
+     * @return the modified listener, for chaining
+     */
+    public FilteredContactListener setBroadPhaseLayerFilter(
+            BroadPhaseLayerFilter bplFilter) {
+        this.bplFilter = bplFilter;
+
+        long listenerVa = va();
+        long bplFilterVa = bplFilter.va();
+        setBroadPhaseLayerFilter(listenerVa, bplFilterVa);
+
+        return this;
+    }
+
+    /**
+     * Alter the broadphase-layer filter mode.
+     *
+     * @param mode the desired mode (not {@code null}, default=Both)
+     * @return the modified listener, for chaining
+     */
+    public FilteredContactListener setBroadPhaseLayerFilterMode(
+            EFilterMode mode) {
+        long listenerVa = va();
+        int ordinal = mode.ordinal();
+        setBroadPhaseLayerFilterMode(listenerVa, ordinal);
+
+        return this;
+    }
+
+    /**
+     * Replace the listener's layer-pair filter.
+     *
+     * @param olpFilter the desired filter, or {@code null} for none
+     * (default=none)
+     * @return the modified listener, for chaining
+     */
+    public FilteredContactListener setObjectLayerPairFilter(
+            ObjectLayerPairFilter olpFilter) {
+        this.olpFilter = olpFilter;
+
+        long listenerVa = va();
+        long olpFilterVa = olpFilter.va();
+        setObjectLayerPairFilter(listenerVa, olpFilterVa);
+
+        return this;
+    }
+    // *************************************************************************
+    // native private methods
+
+    native private long createDefault();
+
+    native private int getBodyFilterMode(long listenerVa);
+
+    native private int getBroadPhaseLayerFilterMode(long listenerVa);
+
+    native private int getObjectLayerFilterMode(long listenerVa);
+
+    native private void setBodyFilter(long listenerVa, long bodyFilterVa);
+
+    native private void setBodyFilterMode(long listenerVa, int ordinal);
+
+    native private void setBroadPhaseLayerFilter(
+            long listenerVa, long bplFilterVa);
+
+    native private void setBroadPhaseLayerFilterMode(
+            long listenerVa, int ordinal);
+
+    native private void setObjectLayerPairFilter(
+            long listenerVa, long olpFilterVa);
+}

--- a/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
+++ b/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
@@ -260,7 +260,7 @@ public class FilteredContactListener extends ContactListener {
     // *************************************************************************
     // native private methods
 
-    native private static long createDefault();
+    native private long createDefault();
 
     native private static int getBodyFilterMode(long listenerVa);
 

--- a/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
+++ b/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
@@ -105,6 +105,54 @@ public class FilteredContactListener extends ContactListener {
     }
 
     /**
+     * Test whether the {@code onContactAdded()} callback is enabled.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     */
+    public boolean getEnableAdded() {
+        long listenerVa = va();
+        boolean result = getEnableAdded(listenerVa);
+
+        return result;
+    }
+
+    /**
+     * Test whether the {@code onContactPersisted()} callback is enabled.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     */
+    public boolean getEnablePersisted() {
+        long listenerVa = va();
+        boolean result = getEnablePersisted(listenerVa);
+
+        return result;
+    }
+
+    /**
+     * Test whether the {@code onContactRemoved()} callback is enabled.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     */
+    public boolean getEnableRemoved() {
+        long listenerVa = va();
+        boolean result = getEnableRemoved(listenerVa);
+
+        return result;
+    }
+
+    /**
+     * Test whether the {@code onContactValidate()} callback is enabled.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     */
+    public boolean getEnableValidate() {
+        long listenerVa = va();
+        boolean result = getEnableValidate(listenerVa);
+
+        return result;
+    }
+
+    /**
      * Access the object-layer pair filter.
      *
      * @return the pre-existing instance, or {@code null} if none
@@ -241,6 +289,50 @@ public class FilteredContactListener extends ContactListener {
     }
 
     /**
+     * Enable or disable the {@code onContactAdded()} callback.
+     *
+     * @param enable {@code true} to enable the callback, {@code false} to
+     * disable it
+     */
+    public void setEnableAdded(boolean enable) {
+        long listenerVa = va();
+        setEnableAdded(listenerVa, enable);
+    }
+
+    /**
+     * Enable or disable the {@code onContactPersisted()} callback.
+     *
+     * @param enable {@code true} to enable the callback, {@code false} to
+     * disable it
+     */
+    public void setEnablePersisted(boolean enable) {
+        long listenerVa = va();
+        setEnablePersisted(listenerVa, enable);
+    }
+
+    /**
+     * Enable or disable the {@code onContactRemoved()} callback.
+     *
+     * @param enable {@code true} to enable the callback, {@code false} to
+     * disable it
+     */
+    public void setEnableRemoved(boolean enable) {
+        long listenerVa = va();
+        setEnableRemoved(listenerVa, enable);
+    }
+
+    /**
+     * Enable or disable the {@code onContactValidate()} callback.
+     *
+     * @param enable {@code true} to enable the callback, {@code false} to
+     * disable it
+     */
+    public void setEnableValidate(boolean enable) {
+        long listenerVa = va();
+        setEnableValidate(listenerVa, enable);
+    }
+
+    /**
      * Replace the listener's layer-pair filter.
      *
      * @param olpFilter the desired filter, or {@code null} for none
@@ -266,6 +358,14 @@ public class FilteredContactListener extends ContactListener {
 
     native private static int getBroadPhaseLayerFilterMode(long listenerVa);
 
+    native private static boolean getEnableAdded(long listenerVa);
+
+    native private static boolean getEnablePersisted(long listenerVa);
+
+    native private static boolean getEnableRemoved(long listenerVa);
+
+    native private static boolean getEnableValidate(long listenerVa);
+
     native private static void setBodyFilter(
             long listenerVa, long bodyFilterVa);
 
@@ -276,6 +376,17 @@ public class FilteredContactListener extends ContactListener {
 
     native private static void setBroadPhaseLayerFilterMode(
             long listenerVa, int ordinal);
+
+    native private static void setEnableAdded(long listenerVa, boolean enable);
+
+    native private static void setEnablePersisted(
+            long listenerVa, boolean enable);
+
+    native private static void setEnableRemoved(
+            long listenerVa, boolean enable);
+
+    native private static void setEnableValidate(
+            long listenerVa, boolean enable);
 
     native private static void setObjectLayerPairFilter(
             long listenerVa, long olpFilterVa);

--- a/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
+++ b/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
@@ -260,22 +260,23 @@ public class FilteredContactListener extends ContactListener {
     // *************************************************************************
     // native private methods
 
-    native private long createDefault();
+    native private static long createDefault();
 
-    native private int getBodyFilterMode(long listenerVa);
+    native private static int getBodyFilterMode(long listenerVa);
 
-    native private int getBroadPhaseLayerFilterMode(long listenerVa);
+    native private static int getBroadPhaseLayerFilterMode(long listenerVa);
 
-    native private void setBodyFilter(long listenerVa, long bodyFilterVa);
+    native private static void setBodyFilter(
+            long listenerVa, long bodyFilterVa);
 
-    native private void setBodyFilterMode(long listenerVa, int ordinal);
+    native private static void setBodyFilterMode(long listenerVa, int ordinal);
 
-    native private void setBroadPhaseLayerFilter(
+    native private static void setBroadPhaseLayerFilter(
             long listenerVa, long bplFilterVa);
 
-    native private void setBroadPhaseLayerFilterMode(
+    native private static void setBroadPhaseLayerFilterMode(
             long listenerVa, int ordinal);
 
-    native private void setObjectLayerPairFilter(
+    native private static void setObjectLayerPairFilter(
             long listenerVa, long olpFilterVa);
 }

--- a/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
+++ b/src/main/java/com/github/stephengold/joltjni/FilteredContactListener.java
@@ -114,19 +114,6 @@ public class FilteredContactListener extends ContactListener {
     }
 
     /**
-     * Return the object-layer filter mode.
-     *
-     * @return a enum value (not {@code null})
-     */
-    public EFilterMode getObjectLayerFilterMode() {
-        long listenerVa = va();
-        int ordinal = getObjectLayerFilterMode(listenerVa);
-        EFilterMode result = EFilterMode.values()[ordinal];
-
-        return result;
-    }
-
-    /**
      * Callback invoked (by native code) each time a new contact point is
      * detected. Meant to be overridden.
      *
@@ -278,8 +265,6 @@ public class FilteredContactListener extends ContactListener {
     native private int getBodyFilterMode(long listenerVa);
 
     native private int getBroadPhaseLayerFilterMode(long listenerVa);
-
-    native private int getObjectLayerFilterMode(long listenerVa);
 
     native private void setBodyFilter(long listenerVa, long bodyFilterVa);
 

--- a/src/main/java/com/github/stephengold/joltjni/enumerate/EFilterMode.java
+++ b/src/main/java/com/github/stephengold/joltjni/enumerate/EFilterMode.java
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.github.stephengold.joltjni.enumerate;
+
+/**
+ * Filter modes for a {@code FilteredContactListener}.
+ *
+ * @author Stephen Gold sgold@sonic.net
+ */
+public enum EFilterMode {
+    // *************************************************************************
+    // values
+
+    /**
+     * invoke associated callbacks if {@code shouldCollide()} returns
+     * {@code true} for both bodies in contact
+     */
+    Both,
+    /**
+     * invoke associated callbacks if {@code shouldCollide()} returns
+     * {@code true} for one body or both bodies in contact
+     */
+    Either,
+    /**
+     * invoke associated callbacks if {@code shouldCollide()} returns
+     * {@code false} for both bodies in contact
+     */
+    Neither,
+    /**
+     * invoke associated callbacks if {@code shouldCollide()} returns
+     * {@code false} for one body or both bodies in contact
+     */
+    NotBoth,
+    /**
+     * don't invoke associated callbacks
+     */
+    Skip
+}

--- a/src/main/native/glue/co/ContactListenerList.cpp
+++ b/src/main/native/glue/co/ContactListenerList.cpp
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Author: Stephen Gold
+ */
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Collision/ContactListener.h"
+#include "auto/com_github_stephengold_joltjni_ContactListenerList.h"
+#include "glue/glue.h"
+
+using namespace JPH;
+
+class ContactListenerList : ContactListener {
+    std::vector<ContactListener *> mSublisteners;
+public:
+    void Erase(jint startIndex, jint stopIndex) {
+        std::vector<ContactListener *>::iterator origin = mSublisteners.begin();
+        mSublisteners.erase(origin + startIndex, origin + stopIndex);
+    }
+    void OnContactAdded(const Body& inBody1, const Body& inBody2,
+            const ContactManifold& inManifold,
+            ContactSettings& ioSettings) override {
+        for (std::vector<ContactListener *>::iterator i = mSublisteners.begin();
+                i != mSublisteners.end(); ++i) {
+            (*i)->OnContactAdded(inBody1, inBody2, inManifold, ioSettings);
+        }
+    }
+    void OnContactPersisted(const Body& inBody1, const Body& inBody2,
+            const ContactManifold& inManifold,
+            ContactSettings& ioSettings) override {
+        for (std::vector<ContactListener *>::iterator i = mSublisteners.begin();
+                i != mSublisteners.end(); ++i) {
+            (*i)->OnContactPersisted(inBody1, inBody2, inManifold, ioSettings);
+        }
+    }
+    void OnContactRemoved(const SubShapeIDPair& pair) override {
+        for (std::vector<ContactListener *>::iterator i = mSublisteners.begin();
+                i != mSublisteners.end(); ++i) {
+            (*i)->OnContactRemoved(pair);
+        }
+    }
+    ValidateResult OnContactValidate(const Body& inBody1, const Body& inBody2,
+            RVec3Arg inBaseOffset,
+            const CollideShapeResult& inCollisionResult) override {
+        jint maxResult = 0;
+        for (std::vector<ContactListener *>::iterator i = mSublisteners.begin();
+                i != mSublisteners.end(); ++i) {
+            ValidateResult valid = (*i)->OnContactValidate(
+                    inBody1, inBody2, inBaseOffset, inCollisionResult);
+            jint ordinal = (jint) valid;
+            maxResult = max(maxResult, ordinal);
+        }
+        return (ValidateResult) maxResult;
+    }
+    void PushBack(ContactListener *pListener) {
+        mSublisteners.push_back(pListener);
+    }
+};
+
+/*
+ * Class:     com_github_stephengold_joltjni_ContactListenerList
+ * Method:    createDefault
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_stephengold_joltjni_ContactListenerList_createDefault
+  BODYOF_CREATE_DEFAULT(ContactListenerList)
+
+/*
+ * Class:     com_github_stephengold_joltjni_ContactListenerList
+ * Method:    erase
+ * Signature: (JII)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_ContactListenerList_erase
+  (JNIEnv *, jclass, jlong listVa, jint startIndex, jint stopIndex) {
+    ContactListenerList * const pList
+            = reinterpret_cast<ContactListenerList *> (listVa);
+    pList->Erase(startIndex, stopIndex);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_ContactListenerList
+ * Method:    free
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_ContactListenerList_free
+  BODYOF_FREE(ContactListenerList)
+
+/*
+ * Class:     com_github_stephengold_joltjni_ContactListenerList
+ * Method:    pushBack
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_ContactListenerList_pushBack
+  (JNIEnv *, jclass, jlong listVa, jlong listenerVa) {
+    ContactListenerList * const pList
+            = reinterpret_cast<ContactListenerList *> (listVa);
+    ContactListener * const pListener
+            = reinterpret_cast<ContactListener *> (listenerVa);
+    pList->PushBack(pListener);
+}

--- a/src/main/native/glue/f/FilteredContactListener.cpp
+++ b/src/main/native/glue/f/FilteredContactListener.cpp
@@ -1,0 +1,433 @@
+/*
+Copyright (c) 2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Author: Stephen Gold
+ */
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Body/Body.h"
+#include "Jolt/Physics/Body/BodyFilter.h"
+#include "Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h"
+#include "Jolt/Physics/Collision/ContactListener.h"
+#include "Jolt/Physics/Collision/ObjectLayer.h"
+
+#include "auto/com_github_stephengold_joltjni_FilteredContactListener.h"
+#include "glue/glue.h"
+
+using namespace JPH;
+
+enum class EFilterMode : jint {
+    Both,
+    Either,
+    Neither,
+    NotBoth,
+    Skip
+};
+class FilteredContactListener : ContactListener {
+    JavaVM *mpVM;
+    jmethodID mAddedMethodId;
+    jmethodID mPersistedMethodId;
+    jmethodID mRemovedMethodId;
+    jmethodID mValidateMethodId;
+    jobject mJavaObject;
+public:
+    bool mEnableAdded = true;
+    bool mEnablePersisted = true;
+    bool mEnableRemoved = true;
+    bool mEnableValidate = true;
+    EFilterMode mBodyFilterMode = EFilterMode::Both;
+    EFilterMode mBplFilterMode = EFilterMode::Both;
+    BodyFilter *mpBodyFilter = nullptr;
+    BroadPhaseLayerFilter *mpBplFilter = nullptr;
+    ObjectLayerPairFilter *mpOlpFilter = nullptr;
+    // constructor:
+    FilteredContactListener(JNIEnv *pEnv, jobject javaObject) {
+        pEnv->GetJavaVM(&mpVM);
+        mJavaObject = pEnv->NewGlobalRef(javaObject);
+        EXCEPTION_CHECK(pEnv)
+        const jclass clss = pEnv->FindClass(
+                "com/github/stephengold/joltjni/FilteredContactListener");
+        EXCEPTION_CHECK(pEnv)
+        mAddedMethodId = pEnv->GetMethodID(clss, "onContactAdded", "(JJJJ)V");
+        EXCEPTION_CHECK(pEnv)
+        mPersistedMethodId
+                = pEnv->GetMethodID(clss, "onContactPersisted", "(JJJJ)V");
+        EXCEPTION_CHECK(pEnv)
+        mRemovedMethodId = pEnv->GetMethodID(clss, "onContactRemoved", "(J)V");
+        EXCEPTION_CHECK(pEnv)
+        mValidateMethodId
+                = pEnv->GetMethodID(clss, "onContactValidate", "(JJDDDJ)I");
+        EXCEPTION_CHECK(pEnv)
+    }
+    void OnContactAdded(const Body& inBody1, const Body& inBody2,
+            const ContactManifold& inManifold,
+            ContactSettings& ioSettings) override {
+        if (!mEnableAdded) {
+            return;
+        }
+        if (SkipBodyPair(inBody1, inBody2)) {
+            return;
+        }
+        JNIEnv *pAttachEnv;
+        jint retCode = ATTACH_CURRENT_THREAD(mpVM, &pAttachEnv);
+        JPH_ASSERT(retCode == JNI_OK);
+        const jlong body1Va = reinterpret_cast<jlong> (&inBody1);
+        const jlong body2Va = reinterpret_cast<jlong> (&inBody2);
+        const jlong manifoldVa = reinterpret_cast<jlong> (&inManifold);
+        const jlong settingsVa = reinterpret_cast<jlong> (&ioSettings);
+        pAttachEnv->CallVoidMethod(mJavaObject, mAddedMethodId,
+                body1Va, body2Va, manifoldVa, settingsVa);
+        EXCEPTION_CHECK(pAttachEnv)
+        mpVM->DetachCurrentThread();
+    }
+    void OnContactPersisted(const Body& inBody1, const Body& inBody2,
+            const ContactManifold& inManifold,
+            ContactSettings& ioSettings) override {
+        if (!mEnablePersisted) {
+            return;
+        }
+        if (SkipBodyPair(inBody1, inBody2)) {
+            return;
+        }
+        JNIEnv *pAttachEnv;
+        jint retCode = ATTACH_CURRENT_THREAD(mpVM, &pAttachEnv);
+        JPH_ASSERT(retCode == JNI_OK);
+        const jlong body1Va = reinterpret_cast<jlong> (&inBody1);
+        const jlong body2Va = reinterpret_cast<jlong> (&inBody2);
+        const jlong manifoldVa = reinterpret_cast<jlong> (&inManifold);
+        const jlong settingsVa = reinterpret_cast<jlong> (&ioSettings);
+        pAttachEnv->CallVoidMethod(mJavaObject, mPersistedMethodId, body1Va,
+                body2Va, manifoldVa, settingsVa);
+        EXCEPTION_CHECK(pAttachEnv)
+        mpVM->DetachCurrentThread();
+    }
+    void OnContactRemoved(const SubShapeIDPair& pair) override {
+        JNIEnv *pAttachEnv;
+        jint retCode = ATTACH_CURRENT_THREAD(mpVM, &pAttachEnv);
+        JPH_ASSERT(retCode == JNI_OK);
+
+        const jlong pairVa = reinterpret_cast<jlong> (&pair);
+        pAttachEnv->CallVoidMethod(mJavaObject, mRemovedMethodId, pairVa);
+        EXCEPTION_CHECK(pAttachEnv)
+        mpVM->DetachCurrentThread();
+    }
+    ValidateResult OnContactValidate(const Body& inBody1, const Body& inBody2,
+            RVec3Arg inBaseOffset,
+            const CollideShapeResult& inCollisionResult) override {
+        if (!mEnableValidate) {
+            return ValidateResult::AcceptAllContactsForThisBodyPair;
+        }
+        if (SkipBodyPair(inBody1, inBody2)) {
+            return ValidateResult::AcceptAllContactsForThisBodyPair;
+        }
+        JNIEnv *pAttachEnv;
+        jint retCode = ATTACH_CURRENT_THREAD(mpVM, &pAttachEnv);
+        JPH_ASSERT(retCode == JNI_OK);
+        const jlong body1Va = reinterpret_cast<jlong> (&inBody1);
+        const jlong body2Va = reinterpret_cast<jlong> (&inBody2);
+        const jdouble offsetX = inBaseOffset.GetX();
+        const jdouble offsetY = inBaseOffset.GetY();
+        const jdouble offsetZ = inBaseOffset.GetZ();
+        const jlong shapeVa = reinterpret_cast<jlong> (&inCollisionResult);
+        const jint jintResult = pAttachEnv->CallIntMethod(mJavaObject,
+                mValidateMethodId, body1Va, body2Va,
+                offsetX, offsetY, offsetZ, shapeVa);
+        EXCEPTION_CHECK(pAttachEnv)
+        mpVM->DetachCurrentThread();
+        return (ValidateResult) jintResult;
+    }
+    bool SkipBodyPair(const Body& inBody1, const Body& inBody2) {
+        if (mBodyFilterMode == EFilterMode::Skip
+                || mBplFilterMode == EFilterMode::Skip) {
+            return true;
+        }
+        if (mpBodyFilter) {
+            const BodyID& id1 = inBody1.GetID();
+            const bool collide1 = mpBodyFilter->ShouldCollide(id1);
+            if (mBodyFilterMode == EFilterMode::Both && !collide1) return true;
+            if (mBodyFilterMode == EFilterMode::Neither && collide1) return true;
+            const BodyID& id2 = inBody2.GetID();
+            const bool collide2 = mpBodyFilter->ShouldCollide(id2);
+            switch (mBodyFilterMode) {
+                case EFilterMode::Both:
+                    if (!collide2) return true;
+                    break;
+                case EFilterMode::Either:
+                    if (!(collide1 || collide2)) return true;
+                    break;
+                case EFilterMode::Neither:
+                    if (collide2) return true;
+                    break;
+                case EFilterMode::NotBoth:
+                    if (collide1 && collide2) return true;
+                    break;
+                case EFilterMode::Skip:
+                    JPH_ASSERT(false);
+            }
+        }
+        if (mpBplFilter) {
+            const BroadPhaseLayer bpl1 = inBody1.GetBroadPhaseLayer();
+            const bool collide1 = mpBplFilter->ShouldCollide(bpl1);
+            if (mBodyFilterMode == EFilterMode::Both && !collide1) return true;
+            if (mBodyFilterMode == EFilterMode::Neither && collide1) return true;
+            const BroadPhaseLayer bpl2 = inBody2.GetBroadPhaseLayer();
+            const bool collide2 = mpBplFilter->ShouldCollide(bpl2);
+            switch (mBodyFilterMode) {
+                case EFilterMode::Both:
+                    if (!collide2) return true;
+                    break;
+                case EFilterMode::Either:
+                    if (!(collide1 || collide2)) return true;
+                    break;
+                case EFilterMode::Neither:
+                    if (collide2) return true;
+                    break;
+                case EFilterMode::NotBoth:
+                    if (collide1 && collide2) return true;
+                case EFilterMode::Skip:
+                    JPH_ASSERT(false);
+            }
+        }
+        if (mpOlpFilter) {
+            const ObjectLayer ol1 = inBody1.GetObjectLayer();
+            const ObjectLayer ol2 = inBody2.GetObjectLayer();
+            const bool collide = mpOlpFilter->ShouldCollide(ol1, ol2);
+            if (!collide) return true;
+        }
+        return false; // don't skip the callback
+    }
+    // destructor:
+    ~FilteredContactListener() {
+        JNIEnv *pAttachEnv;
+        jint retCode = ATTACH_CURRENT_THREAD(mpVM, &pAttachEnv);
+        JPH_ASSERT(retCode == JNI_OK);
+        pAttachEnv->DeleteGlobalRef(mJavaObject);
+        EXCEPTION_CHECK(pAttachEnv)
+        mpVM->DetachCurrentThread();
+    }
+};
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    createDefault
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_createDefault
+  (JNIEnv *pEnv, jobject javaObject) {
+    FilteredContactListener * const pResult
+            = new FilteredContactListener(pEnv, javaObject);
+    TRACE_NEW("FilteredContactListener", pResult)
+    return reinterpret_cast<jlong> (pResult);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getBodyFilterMode
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getBodyFilterMode
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const EFilterMode result = pListener->mBodyFilterMode;
+    return (jint) result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getBroadPhaseLayerFilterMode
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getBroadPhaseLayerFilterMode
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const EFilterMode result = pListener->mBplFilterMode;
+    return (jint) result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getEnableAdded
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getEnableAdded
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const bool result = pListener->mEnableAdded;
+    return result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getEnablePersisted
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getEnablePersisted
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const bool result = pListener->mEnablePersisted;
+    return result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getEnableRemoved
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getEnableRemoved
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const bool result = pListener->mEnableRemoved;
+    return result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    getEnableValidate
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_getEnableValidate
+  (JNIEnv *, jclass, jlong listenerVa) {
+    const FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const bool result = pListener->mEnableValidate;
+    return result;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setBodyFilter
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setBodyFilter
+  (JNIEnv *, jclass, jlong listenerVa, jlong bodyFilterVa) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    BodyFilter * const pFilter = reinterpret_cast<BodyFilter *> (bodyFilterVa);
+    pListener->mpBodyFilter = pFilter;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setBodyFilterMode
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setBodyFilterMode
+  (JNIEnv *, jclass, jlong listenerVa, jint ordinal) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const EFilterMode mode = (EFilterMode) ordinal;
+    pListener->mBodyFilterMode = mode;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setBroadPhaseLayerFilter
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setBroadPhaseLayerFilter
+  (JNIEnv *, jclass, jlong listenerVa, jlong bplFilterVa) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    BroadPhaseLayerFilter * const pFilter
+            = reinterpret_cast<BroadPhaseLayerFilter *> (bplFilterVa);
+    pListener->mpBplFilter = pFilter;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setBroadPhaseLayerFilterMode
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setBroadPhaseLayerFilterMode
+  (JNIEnv *, jclass, jlong listenerVa, jint ordinal) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    const EFilterMode mode = (EFilterMode) ordinal;
+    pListener->mBplFilterMode = mode;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setEnableAdded
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setEnableAdded
+  (JNIEnv *, jclass, jlong listenerVa, jboolean enable) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    pListener->mEnableAdded = enable;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setEnablePersisted
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setEnablePersisted
+  (JNIEnv *, jclass, jlong listenerVa, jboolean enable) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    pListener->mEnablePersisted = enable;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setEnableRemoved
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setEnableRemoved
+  (JNIEnv *, jclass, jlong listenerVa, jboolean enable) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    pListener->mEnableRemoved = enable;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setEnableValidate
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setEnableValidate
+  (JNIEnv *, jclass, jlong listenerVa, jboolean enable) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    pListener->mEnableValidate = enable;
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_FilteredContactListener
+ * Method:    setObjectLayerPairFilter
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_FilteredContactListener_setObjectLayerPairFilter
+  (JNIEnv *, jclass, jlong listenerVa, jlong olpFilterVa) {
+    FilteredContactListener * const pListener
+            = reinterpret_cast<FilteredContactListener *> (listenerVa);
+    ObjectLayerPairFilter * const pFilter
+            = reinterpret_cast<ObjectLayerPairFilter *> (olpFilterVa);
+    pListener->mpOlpFilter = pFilter;
+}


### PR DESCRIPTION
This PR attempts to reduce the cost associated with `PhysicsSystem.setContactListener()` when there are many rigid-body contacts.

1. `FilteredContactListener` is a contact listener that enables an application to filter contacts using a `BodyFilter`, a `BroadPhaseLayerFilter`, an `ObjectLayerPairFilter`, or any combination of the 3. If filtering is performed entirely in native code, the number of JNI callbacks into Java is reduced accordingly.
2. Since `BodyFilter` and `BroadPhaseLayerFilter` operate on one body at a time, `EFilterMode` enumerates ways to use filter results (from the 2 bodies in contact) to decide whether to invoke JNI callbacks into Java.
3. `ContactListenerList` enables the contact-listener logic of a single `PhysicsSystem` to be cleanly partitioned across multiple listeners. This is useful when application subsystems need access to different subsets of the contact information. The expectation is that a `ContactListenerList` will contain filtered contact listeners, but it might potentially include ordinary custom contact listeners or other contact-listener lists.

The initial commit is incomplete, for API review. Glue code will be added after the API is approved.