### PR TITLE
Add Batch removeBodies & destroyBodies to BodyInterface

### DIFF
--- a/src/main/java/com/github/stephengold/joltjni/BodyInterface.java
+++ b/src/main/java/com/github/stephengold/joltjni/BodyInterface.java
@@ -424,17 +424,6 @@ public class BodyInterface extends NonCopyable {
     }
 
     /**
-     * Destroy the specified body. Don't use this on a body that has been added
-     * but not removed yet!
-     *
-     * @param bodyId the ID of the body to destroy
-     */
-    public void destroyBody(int bodyId) {
-        long bodyInterfaceVa = va();
-        destroyBody(bodyInterfaceVa, bodyId);
-    }
-
-    /**
      * Destroy the specified bodies. Don't use this on bodies that have been
      * added but not removed yet!
      *
@@ -456,6 +445,17 @@ public class BodyInterface extends NonCopyable {
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
         destroyBodies(bodyInterfaceVa, arrayVa, numBodies);
+    }
+
+    /**
+     * Destroy the specified body. Don't use this on a body that has been added
+     * but not removed yet!
+     *
+     * @param bodyId the ID of the body to destroy
+     */
+    public void destroyBody(int bodyId) {
+        long bodyInterfaceVa = va();
+        destroyBody(bodyInterfaceVa, bodyId);
     }
 
     /**
@@ -873,16 +873,6 @@ public class BodyInterface extends NonCopyable {
     }
 
     /**
-     * Remove the specified body from the physics system, but don't destroy it.
-     *
-     * @param bodyId the ID of the body to remove
-     */
-    public void removeBody(int bodyId) {
-        long bodyInterfaceVa = va();
-        removeBody(bodyInterfaceVa, bodyId);
-    }
-
-    /**
      * Remove the specified bodies from the physics system, but don't destroy
      * them.
      *
@@ -904,6 +894,16 @@ public class BodyInterface extends NonCopyable {
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
         removeBodies(bodyInterfaceVa, arrayVa, numBodies);
+    }
+
+    /**
+     * Remove the specified body from the physics system, but don't destroy it.
+     *
+     * @param bodyId the ID of the body to remove
+     */
+    public void removeBody(int bodyId) {
+        long bodyInterfaceVa = va();
+        removeBody(bodyInterfaceVa, bodyId);
     }
 
     /**
@@ -1182,10 +1182,10 @@ public class BodyInterface extends NonCopyable {
 
     native private static void deactivateBody(long bodyInterfaceVa, int bodyId);
 
-    native private static void destroyBody(long bodyInterfaceVa, int bodyId);
-
     native private static void destroyBodies(
             long bodyInterfaceVa, long arrayVa, int numBodies);
+
+    native private static void destroyBody(long bodyInterfaceVa, int bodyId);
 
     native private static void getAngularVelocity(
             long bodyInterfaceVa, int bodyId, FloatBuffer storeFloats);
@@ -1252,10 +1252,10 @@ public class BodyInterface extends NonCopyable {
             int bodyId, float prevX, float prevY, float prevZ,
             boolean updateMassProperties, int activationOrdinal);
 
-    native private static void removeBody(long bodyInterfaceVa, int bodyId);
-
     native private static void removeBodies(
             long bodyInterfaceVa, long arrayVa, int numBodies);
+
+    native private static void removeBody(long bodyInterfaceVa, int bodyId);
 
     native private static void setAngularVelocity(
             long bodyInterfaceVa, int bodyId, float wx, float wy, float wz);

--- a/src/main/java/com/github/stephengold/joltjni/BodyInterface.java
+++ b/src/main/java/com/github/stephengold/joltjni/BodyInterface.java
@@ -435,6 +435,30 @@ public class BodyInterface extends NonCopyable {
     }
 
     /**
+     * Destroy the specified bodies. Don't use this on bodies that have been
+     * added but not removed yet!
+     *
+     * @param bodyIds the IDs of the bodies to destroy (not null)
+     */
+    public void destroyBodies(BodyIdArray bodyIds) {
+        int numBodies = bodyIds.length();
+        destroyBodies(bodyIds, numBodies);
+    }
+
+    /**
+     * Destroy the specified bodies. Don't use this on bodies that have been
+     * added but not removed yet!
+     *
+     * @param bodyIds the IDs of the bodies to destroy (not null)
+     * @param numBodies the number of bodies to destroy (&ge;0)
+     */
+    public void destroyBodies(BodyIdArray bodyIds, int numBodies) {
+        long bodyInterfaceVa = va();
+        long arrayVa = bodyIds.va();
+        destroyBodies(bodyInterfaceVa, arrayVa, numBodies);
+    }
+
+    /**
      * Return the angular velocity of the specified body.
      *
      * @param bodyId the ID of the body
@@ -859,6 +883,30 @@ public class BodyInterface extends NonCopyable {
     }
 
     /**
+     * Remove the specified bodies from the physics system, but don't destroy
+     * them.
+     *
+     * @param bodyIds the IDs of the bodies to remove (not null)
+     */
+    public void removeBodies(BodyIdArray bodyIds) {
+        int numBodies = bodyIds.length();
+        removeBodies(bodyIds, numBodies);
+    }
+
+    /**
+     * Remove the specified bodies from the physics system, but don't destroy
+     * them.
+     *
+     * @param bodyIds the IDs of the bodies to remove (not null)
+     * @param numBodies the number of bodies to remove (&ge;0)
+     */
+    public void removeBodies(BodyIdArray bodyIds, int numBodies) {
+        long bodyInterfaceVa = va();
+        long arrayVa = bodyIds.va();
+        removeBodies(bodyInterfaceVa, arrayVa, numBodies);
+    }
+
+    /**
      * Alter the angular velocity of the specified body.
      *
      * @param bodyId the ID of the body to modify
@@ -1136,6 +1184,9 @@ public class BodyInterface extends NonCopyable {
 
     native private static void destroyBody(long bodyInterfaceVa, int bodyId);
 
+    native private static void destroyBodies(
+            long bodyInterfaceVa, long arrayVa, int numBodies);
+
     native private static void getAngularVelocity(
             long bodyInterfaceVa, int bodyId, FloatBuffer storeFloats);
 
@@ -1202,6 +1253,9 @@ public class BodyInterface extends NonCopyable {
             boolean updateMassProperties, int activationOrdinal);
 
     native private static void removeBody(long bodyInterfaceVa, int bodyId);
+
+    native private static void removeBodies(
+            long bodyInterfaceVa, long arrayVa, int numBodies);
 
     native private static void setAngularVelocity(
             long bodyInterfaceVa, int bodyId, float wx, float wy, float wz);

--- a/src/main/native/glue/bo/BodyInterface.cpp
+++ b/src/main/native/glue/bo/BodyInterface.cpp
@@ -294,19 +294,6 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_deactiv
 
 /*
  * Class:     com_github_stephengold_joltjni_BodyInterface
- * Method:    destroyBody
- * Signature: (JI)V
- */
-JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_destroyBody
-  (JNIEnv *, jclass, jlong bodyInterfaceVa, jint bodyId) {
-    BodyInterface * const pInterface
-            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
-    const BodyID id(bodyId);
-    pInterface->DestroyBody(id);
-}
-
-/*
- * Class:     com_github_stephengold_joltjni_BodyInterface
  * Method:    destroyBodies
  * Signature: (JJI)V
  */
@@ -316,6 +303,19 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_destroy
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
     pInterface->DestroyBodies(pArray, numBodies);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_BodyInterface
+ * Method:    destroyBody
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_destroyBody
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jint bodyId) {
+    BodyInterface * const pInterface
+            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
+    const BodyID id(bodyId);
+    pInterface->DestroyBody(id);
 }
 
 /*
@@ -702,19 +702,6 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_notifyS
 
 /*
  * Class:     com_github_stephengold_joltjni_BodyInterface
- * Method:    removeBody
- * Signature: (JI)V
- */
-JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_removeBody
-  (JNIEnv *, jclass, jlong bodyInterfaceVa, jint bodyId) {
-    BodyInterface * const pInterface
-            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
-    const BodyID id(bodyId);
-    pInterface->RemoveBody(id);
-}
-
-/*
- * Class:     com_github_stephengold_joltjni_BodyInterface
  * Method:    removeBodies
  * Signature: (JJI)V
  */
@@ -724,6 +711,19 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_removeB
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     BodyID * const pArray = reinterpret_cast<BodyID *> (arrayVa);
     pInterface->RemoveBodies(pArray, numBodies);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_BodyInterface
+ * Method:    removeBody
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_removeBody
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jint bodyId) {
+    BodyInterface * const pInterface
+            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
+    const BodyID id(bodyId);
+    pInterface->RemoveBody(id);
 }
 
 /*

--- a/src/main/native/glue/bo/BodyInterface.cpp
+++ b/src/main/native/glue/bo/BodyInterface.cpp
@@ -307,6 +307,19 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_destroy
 
 /*
  * Class:     com_github_stephengold_joltjni_BodyInterface
+ * Method:    destroyBodies
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_destroyBodies
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies) {
+    BodyInterface * const pInterface
+            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
+    const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
+    pInterface->DestroyBodies(pArray, numBodies);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_BodyInterface
  * Method:    getAngularVelocity
  * Signature: (JILjava/nio/FloatBuffer;)V
  */
@@ -698,6 +711,19 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_removeB
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID id(bodyId);
     pInterface->RemoveBody(id);
+}
+
+/*
+ * Class:     com_github_stephengold_joltjni_BodyInterface
+ * Method:    removeBodies
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BodyInterface_removeBodies
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies) {
+    BodyInterface * const pInterface
+            = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
+    BodyID * const pArray = reinterpret_cast<BodyID *> (arrayVa);
+    pInterface->RemoveBodies(pArray, numBodies);
 }
 
 /*

--- a/src/test/java/testjoltjni/junit/BodyRemovalTest.java
+++ b/src/test/java/testjoltjni/junit/BodyRemovalTest.java
@@ -1,0 +1,161 @@
+/*
+Copyright (c) 2024-2025 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package testjoltjni.junit;
+
+import com.github.stephengold.joltjni.BodyCreationSettings;
+import com.github.stephengold.joltjni.BodyIdArray;
+import com.github.stephengold.joltjni.BodyInterface;
+import com.github.stephengold.joltjni.PhysicsSystem;
+import com.github.stephengold.joltjni.Quat;
+import com.github.stephengold.joltjni.RVec3;
+import com.github.stephengold.joltjni.SphereShape;
+import com.github.stephengold.joltjni.enumerate.EActivation;
+import com.github.stephengold.joltjni.enumerate.EMotionType;
+import org.junit.Assert;
+import org.junit.Test;
+import testjoltjni.TestUtils;
+
+/**
+ * Automated JUnit4 tests for batch removal and destruction operations in
+ * {@code BodyInterface}.
+ *
+ * @author xI-Mx-Ix
+ */
+public class BodyRemovalTest {
+    // *************************************************************************
+    // new methods exposed
+
+    /**
+     * Test batch removal and destruction in {@code BodyInterface}.
+     */
+    @Test
+    public void testBodyRemoval() {
+        TestUtils.loadNativeLibrary();
+        TestUtils.initializeNativeLibrary();
+
+        PhysicsSystem physicsSystem = TestUtils.newPhysicsSystem(100);
+        BodyInterface bodyInterface = physicsSystem.getBodyInterface();
+
+        testRemoveAndDestroyBodies(bodyInterface);
+
+        TestUtils.cleanupPhysicsSystem(physicsSystem);
+        TestUtils.cleanup();
+    }
+
+    // *************************************************************************
+    // private methods
+
+    /**
+     * A helper method to create a simple dynamic sphere and add it to the
+     * world.
+     *
+     * @param bodyInterface the interface to use (not null)
+     * @param position the initial position of the body (not null, unaffected)
+     * @return the ID of the newly created body
+     */
+    private static int createAndAddBody(BodyInterface bodyInterface,
+                                        RVec3 position) {
+        int objectLayer = TestUtils.objLayerMoving;
+        SphereShape shape = new SphereShape(0.5f);
+        BodyCreationSettings settings = new BodyCreationSettings(
+                shape, position, new Quat(),
+                EMotionType.Dynamic, objectLayer
+        );
+
+        int bodyId = bodyInterface.createAndAddBody(
+                settings, EActivation.Activate);
+
+        TestUtils.testClose(settings, shape);
+        return bodyId;
+    }
+
+    /**
+     * Test the batch-remove and batch-destroy functionality of the specified
+     * {@code BodyInterface}.
+     *
+     * @param bodyInterface the interface to test (not null)
+     */
+    private static void testRemoveAndDestroyBodies(
+            BodyInterface bodyInterface) {
+        final int numBodies = 3;
+        BodyIdArray ids = new BodyIdArray(numBodies);
+
+        // 1. Create and add some bodies.
+        for (int i = 0; i < numBodies; ++i) {
+            RVec3 pos = new RVec3(i * 2f, 10f, 0f);
+            int bodyId = createAndAddBody(bodyInterface, pos);
+            Assert.assertTrue(bodyInterface.isAdded(bodyId));
+            ids.set(i, bodyId);
+        }
+
+        // --- Test RemoveBodies ---
+        // 2. Remove all bodies in a single batch call.
+        bodyInterface.removeBodies(ids);
+
+        // 3. Verify they are all marked as 'not added'.
+        for (int i = 0; i < numBodies; ++i) {
+            Assert.assertFalse(
+                    "Body should be removed",
+                    bodyInterface.isAdded(ids.get(i))
+            );
+        }
+
+        // 4. Re-add the bodies to prove they still exist and were not
+        // destroyed.
+        for (int i = 0; i < numBodies; ++i) {
+            bodyInterface.addBody(ids.get(i), EActivation.Activate);
+            Assert.assertTrue(
+                    "Body should be re-added successfully",
+                    bodyInterface.isAdded(ids.get(i))
+            );
+        }
+
+        // --- Test DestroyBodies ---
+        // 5. Must remove them again from the simulation before destroying.
+        bodyInterface.removeBodies(ids);
+        for (int i = 0; i < numBodies; ++i) {
+            Assert.assertFalse(
+                    "Body should be removed again before destroy",
+                    bodyInterface.isAdded(ids.get(i))
+            );
+        }
+
+        // 6. Destroy all bodies permanently in a single batch call.
+        bodyInterface.destroyBodies(ids);
+
+        // 7. Verify they cannot be re-added, as their IDs are now invalid.
+        for (int i = 0; i < numBodies; ++i) {
+            int bodyId = ids.get(i);
+            // isAdded() is safe to call on invalid IDs; it returns false.
+            Assert.assertFalse(bodyInterface.isAdded(bodyId));
+
+            // Attempting to re-add an invalid ID should fail silently.
+            bodyInterface.addBody(bodyId, EActivation.Activate);
+            Assert.assertFalse(
+                    "Body should not be added after being destroyed",
+                    bodyInterface.isAdded(bodyId)
+            );
+        }
+
+        TestUtils.testClose(ids);
+    }
+}

--- a/src/test/java/testjoltjni/junit/BodyRemovalTest.java
+++ b/src/test/java/testjoltjni/junit/BodyRemovalTest.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024-2025 Stephen Gold
+Copyright (c) 2025 Stephen Gold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This adds two new convenience methods to handle multiple bodies at once instead of having to loop through them individually.

**New methods:**
`removeBodies(BodyIdArray bodyIds)` - removes multiple bodies from the physics system in one call
`destroyBodies(BodyIdArray bodyIds)` - permanently destroys multiple bodies that were already removed

Both methods work the same way as their single-body counterparts, just more efficiently when you need to process many bodies. You still need to remove bodies before destroying them.

I've added a proper test case (`BodyRemovalTest`) that creates some bodies, tests the batch removal (and verifies they can be re-added), then tests batch destruction (and confirms they're gone for good). All tests pass and the code is Checkstyle compliant.

This should be particularly useful for scenarios where you're cleaning up large numbers of physics bodies, like when resetting a level or clearing debris.