### PR TITLE
Fix memory leak in getTransformedShape by adding TRACE_NEW

### DIFF
--- a/src/main/native/glue/bo/BodyInterface.cpp
+++ b/src/main/native/glue/bo/BodyInterface.cpp
@@ -593,6 +593,7 @@ JNIEXPORT jlong JNICALL Java_com_github_stephengold_joltjni_BodyInterface_getTra
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID id(bodyId);
     TransformedShape * const pResult = new TransformedShape();
+    TRACE_NEW("TransformedShape", pResult)
     *pResult = pInterface->GetTransformedShape(id);
     return reinterpret_cast<jlong> (pResult);
 }


### PR DESCRIPTION
This PR addresses issue #35 by adding the missing TRACE_NEW macro to the `getTransformedShape` implementation in `BodyInterface.cpp`. This ensures that the native memory tracking stays balanced for this method.