### PR TITLE
Update BatchBodyInterface to use specialized array classes

### DIFF
--- a/src/main/java/com/github/stephengold/joltjni/BatchBodyInterface.java
+++ b/src/main/java/com/github/stephengold/joltjni/BatchBodyInterface.java
@@ -160,17 +160,16 @@ public class BatchBodyInterface extends BodyInterface {
      * Return the center-of-mass transforms of the specified bodies.
      *
      * @param bodyIds the IDs of the bodies to locate (not null)
-     * @param storeMatrices storage for the matrices (not null, 16 doubles per
-     * body, interleaved, modified)
+     * @param storeMatrices storage for the matrices (not null, modified)
      */
     public void getCenterOfMassTransforms(
-            BodyIdArray bodyIds, DoubleBuffer storeMatrices) {
+            BodyIdArray bodyIds, RMat44Array storeMatrices) {
         int numBodies = bodyIds.length();
-        assert storeMatrices.capacity() >= numBodies * 16;
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
+        long matricesVa = storeMatrices.va();
         getCenterOfMassTransforms(
-                bodyInterfaceVa, arrayVa, numBodies, storeMatrices);
+                bodyInterfaceVa, arrayVa, numBodies, matricesVa);
     }
 
     /**
@@ -210,17 +209,16 @@ public class BatchBodyInterface extends BodyInterface {
      * Copy the inverses of the inertia tensors in system coordinates.
      *
      * @param bodyIds the IDs of the bodies to query (not null)
-     * @param storeMatrices storage for the matrices (not null, 16 floats per
-     * body, interleaved, modified)
+     * @param storeMatrices storage for the matrices (not null, modified)
      */
     public void getInverseInertias(
-            BodyIdArray bodyIds, FloatBuffer storeMatrices) {
+            BodyIdArray bodyIds, Mat44Array storeMatrices) {
         int numBodies = bodyIds.length();
-        assert storeMatrices.capacity() >= numBodies * 16;
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
+        long matricesVa = storeMatrices.va();
         getInverseInertias(
-                bodyInterfaceVa, arrayVa, numBodies, storeMatrices);
+                bodyInterfaceVa, arrayVa, numBodies, matricesVa);
     }
 
     /**
@@ -339,41 +337,31 @@ public class BatchBodyInterface extends BodyInterface {
      * Access the shapes of the specified bodies.
      *
      * @param bodyIds the IDs of the bodies (not null)
-     * @return a new array of new references
+     * @param storeShapes storage for the references (not null, modified)
      */
-    public ShapeRefC[] getShapes(BodyIdArray bodyIds) {
+    public void getShapes(BodyIdArray bodyIds, ShapeRefCArray storeShapes) {
         int numBodies = bodyIds.length();
-        LongBuffer storeShapeVas = Jolt.newDirectLongBuffer(numBodies);
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
-        getShapes(bodyInterfaceVa, arrayVa, numBodies, storeShapeVas);
-        ShapeRefC[] result = new ShapeRefC[numBodies];
-        for (int i = 0; i < numBodies; ++i) {
-            long va = storeShapeVas.get(i);
-            result[i] = new ShapeRefC(va, true);
-        }
-        return result;
+        long shapesVa = storeShapes.va();
+        getShapes(bodyInterfaceVa, arrayVa, numBodies, shapesVa);
     }
 
     /**
      * Generate transformed shapes for the specified bodies.
      *
      * @param bodyIds the IDs of the bodies (not null)
-     * @return a new array of new objects
+     * @param storeShapes storage for the transformed shapes (not null,
+     * modified)
      */
-    public TransformedShape[] getTransformedShapes(BodyIdArray bodyIds) {
+    public void getTransformedShapes(
+            BodyIdArray bodyIds, TransformedShapeArray storeShapes) {
         int numBodies = bodyIds.length();
-        LongBuffer storeShapeVas = Jolt.newDirectLongBuffer(numBodies);
         long bodyInterfaceVa = va();
         long arrayVa = bodyIds.va();
+        long shapesVa = storeShapes.va();
         getTransformedShapes(
-                bodyInterfaceVa, arrayVa, numBodies, storeShapeVas);
-        TransformedShape[] result = new TransformedShape[numBodies];
-        for (int i = 0; i < numBodies; ++i) {
-            long va = storeShapeVas.get(i);
-            result[i] = new TransformedShape(va, true);
-        }
-        return result;
+                bodyInterfaceVa, arrayVa, numBodies, shapesVa);
     }
 
     /**
@@ -555,7 +543,7 @@ public class BatchBodyInterface extends BodyInterface {
             long arrayVa, int numBodies, DoubleBuffer storePositions);
 
     native private static void getCenterOfMassTransforms(long bodyInterfaceVa,
-            long arrayVa, int numBodies, DoubleBuffer storeMatrices);
+            long arrayVa, int numBodies, long matricesVa);
 
     native private static void getFrictions(long bodyInterfaceVa, long arrayVa,
             int numBodies, FloatBuffer storeFrictions);
@@ -564,7 +552,7 @@ public class BatchBodyInterface extends BodyInterface {
             long arrayVa, int numBodies, FloatBuffer storeFactors);
 
     native private static void getInverseInertias(long bodyInterfaceVa,
-            long arrayVa, int numBodies, FloatBuffer storeMatrices);
+            long arrayVa, int numBodies, long matricesVa);
 
     native private static void getLinearVelocities(long bodyInterfaceVa,
             long arrayVa, int numBodies, FloatBuffer storeVelocities);
@@ -588,10 +576,10 @@ public class BatchBodyInterface extends BodyInterface {
             int numBodies, FloatBuffer storeOrientations);
 
     native private static void getShapes(long bodyInterfaceVa, long arrayVa,
-            int numBodies, LongBuffer storeShapeVas);
+            int numBodies, long shapesVa);
 
     native private static void getTransformedShapes(long bodyInterfaceVa,
-            long arrayVa, int numBodies, LongBuffer storeShapeVas);
+            long arrayVa, int numBodies, long shapesVa);
 
     native private static void getUseManifoldReductions(long bodyInterfaceVa,
             long arrayVa, int numBodies, ByteBuffer storeStatus);

--- a/src/main/native/glue/ba/BatchBodyInterface.cpp
+++ b/src/main/native/glue/ba/BatchBodyInterface.cpp
@@ -151,31 +151,17 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_ge
 /*
  * Class:     com_github_stephengold_joltjni_BatchBodyInterface
  * Method:    getCenterOfMassTransforms
- * Signature: (JJILjava/nio/DoubleBuffer;)V
+ * Signature: (JJIJ)V
  */
 JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_getCenterOfMassTransforms
-  (JNIEnv *pEnv, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
-  jobject storeMatrices) {
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
+  jlong matricesVa) {
     const BodyInterface * const pInterface
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
-    DIRECT_DOUBLE_BUFFER(pEnv, storeMatrices, pOut, capacity);
-    JPH_ASSERT(capacity >= numBodies * 16);
+    RMat44 * const pMatrices = reinterpret_cast<RMat44 *> (matricesVa);
     for (jlong i = 0; i < numBodies; ++i) {
-        RMat44 m = pInterface->GetCenterOfMassTransform(pArray[i]);
-        jlong offset = i * 16;
-        for (uint col = 0; col < 3; ++col) {
-            Vec4 v = m.GetColumn4(col);
-            pOut[offset + col * 4 + 0] = (jdouble) v.GetX();
-            pOut[offset + col * 4 + 1] = (jdouble) v.GetY();
-            pOut[offset + col * 4 + 2] = (jdouble) v.GetZ();
-            pOut[offset + col * 4 + 3] = (jdouble) v.GetW();
-        }
-        RVec3 t = m.GetTranslation();
-        pOut[offset + 12] = (jdouble) t.GetX();
-        pOut[offset + 13] = (jdouble) t.GetY();
-        pOut[offset + 14] = (jdouble) t.GetZ();
-        pOut[offset + 15] = 1.0;
+        pMatrices[i] = pInterface->GetCenterOfMassTransform(pArray[i]);
     }
 }
 
@@ -218,26 +204,17 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_ge
 /*
  * Class:     com_github_stephengold_joltjni_BatchBodyInterface
  * Method:    getInverseInertias
- * Signature: (JJILjava/nio/FloatBuffer;)V
+ * Signature: (JJIJ)V
  */
 JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_getInverseInertias
-  (JNIEnv *pEnv, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
-  jobject storeMatrices) {
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
+  jlong matricesVa) {
     const BodyInterface * const pInterface
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
-    DIRECT_FLOAT_BUFFER(pEnv, storeMatrices, pOut, capacity);
-    JPH_ASSERT(capacity >= numBodies * 16);
+    Mat44 * const pMatrices = reinterpret_cast<Mat44 *> (matricesVa);
     for (jlong i = 0; i < numBodies; ++i) {
-        Mat44 m = pInterface->GetInverseInertia(pArray[i]);
-        jlong offset = i * 16;
-        for (uint col = 0; col < 4; ++col) {
-            Vec4 v = m.GetColumn4(col);
-            pOut[offset + col * 4 + 0] = v.GetX();
-            pOut[offset + col * 4 + 1] = v.GetY();
-            pOut[offset + col * 4 + 2] = v.GetZ();
-            pOut[offset + col * 4 + 3] = v.GetW();
-        }
+        pMatrices[i] = pInterface->GetInverseInertia(pArray[i]);
     }
 }
 
@@ -380,42 +357,34 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_ge
 /*
  * Class:     com_github_stephengold_joltjni_BatchBodyInterface
  * Method:    getShapes
- * Signature: (JJILjava/nio/LongBuffer;)V
+ * Signature: (JJIJ)V
  */
 JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_getShapes
-  (JNIEnv *pEnv, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
-  jobject storeShapeVas) {
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
+  jlong shapesVa) {
     const BodyInterface * const pInterface
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
-    DIRECT_LONG_BUFFER(pEnv, storeShapeVas, pOut, capacity);
-    JPH_ASSERT(capacity >= numBodies);
+    ShapeRefC * const pShapes = reinterpret_cast<ShapeRefC *> (shapesVa);
     for (jlong i = 0; i < numBodies; ++i) {
-        ShapeRefC * const pResult = new ShapeRefC();
-        TRACE_NEW("ShapeRefC", pResult)
-        *pResult = pInterface->GetShape(pArray[i]);
-        pOut[i] = reinterpret_cast<jlong> (pResult);
+        pShapes[i] = pInterface->GetShape(pArray[i]);
     }
 }
 
 /*
  * Class:     com_github_stephengold_joltjni_BatchBodyInterface
  * Method:    getTransformedShapes
- * Signature: (JJILjava/nio/LongBuffer;)V
+ * Signature: (JJIJ)V
  */
 JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_BatchBodyInterface_getTransformedShapes
-  (JNIEnv *pEnv, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
-  jobject storeShapeVas) {
+  (JNIEnv *, jclass, jlong bodyInterfaceVa, jlong arrayVa, jint numBodies,
+  jlong shapesVa) {
     const BodyInterface * const pInterface
             = reinterpret_cast<BodyInterface *> (bodyInterfaceVa);
     const BodyID * const pArray = reinterpret_cast<const BodyID *> (arrayVa);
-    DIRECT_LONG_BUFFER(pEnv, storeShapeVas, pOut, capacity);
-    JPH_ASSERT(capacity >= numBodies);
+    TransformedShape * const pShapes = reinterpret_cast<TransformedShape *> (shapesVa);
     for (jlong i = 0; i < numBodies; ++i) {
-        TransformedShape * const pResult = new TransformedShape();
-        TRACE_NEW("TransformedShape", pResult)
-        *pResult = pInterface->GetTransformedShape(pArray[i]);
-        pOut[i] = reinterpret_cast<jlong> (pResult);
+        pShapes[i] = pInterface->GetTransformedShape(pArray[i]);
     }
 }
 

--- a/src/test/java/testjoltjni/junit/BodyBatchQueryTest.java
+++ b/src/test/java/testjoltjni/junit/BodyBatchQueryTest.java
@@ -25,13 +25,18 @@ import com.github.stephengold.joltjni.BatchBodyInterface;
 import com.github.stephengold.joltjni.BodyCreationSettings;
 import com.github.stephengold.joltjni.BodyIdArray;
 import com.github.stephengold.joltjni.Jolt;
+import com.github.stephengold.joltjni.Mat44;
+import com.github.stephengold.joltjni.Mat44Array;
 import com.github.stephengold.joltjni.PhysicsSystem;
 import com.github.stephengold.joltjni.Quat;
 import com.github.stephengold.joltjni.RMat44;
+import com.github.stephengold.joltjni.RMat44Array;
 import com.github.stephengold.joltjni.RVec3;
 import com.github.stephengold.joltjni.ShapeRefC;
+import com.github.stephengold.joltjni.ShapeRefCArray;
 import com.github.stephengold.joltjni.SphereShape;
 import com.github.stephengold.joltjni.TransformedShape;
+import com.github.stephengold.joltjni.TransformedShapeArray;
 import com.github.stephengold.joltjni.Vec3;
 import com.github.stephengold.joltjni.enumerate.EActivation;
 import com.github.stephengold.joltjni.enumerate.EMotionType;
@@ -201,28 +206,33 @@ public class BodyBatchQueryTest {
         }
 
         // Verify Shapes
-        ShapeRefC[] batchShapes = bi.getShapes(ids);
+        ShapeRefCArray batchShapes = new ShapeRefCArray(n);
+        bi.getShapes(ids, batchShapes);
         for (int i = 0; i < n; ++i) {
             ShapeRefC singularRef = bi.getShape(ids.get(i));
-            Assert.assertEquals(
-                    singularRef.targetVa(), batchShapes[i].targetVa());
-            TestUtils.testClose(singularRef, batchShapes[i]);
+            ShapeRefC arrayRef = batchShapes.get(i);
+            Assert.assertEquals(singularRef.targetVa(), arrayRef.targetVa());
+            TestUtils.testClose(singularRef, arrayRef);
         }
+        TestUtils.testClose(batchShapes);
 
         // Verify TransformedShapes
-        TransformedShape[] batchTs = bi.getTransformedShapes(ids);
+        TransformedShapeArray batchTs = new TransformedShapeArray(n);
+        bi.getTransformedShapes(ids, batchTs);
         for (int i = 0; i < n; ++i) {
             TransformedShape singularTs = bi.getTransformedShape(ids.get(i));
+            TransformedShape arrayTs = batchTs.get(i);
             ConstShape s1 = singularTs.getShape();
-            ConstShape s2 = batchTs[i].getShape();
+            ConstShape s2 = arrayTs.getShape();
 
             Assert.assertEquals(s1.targetVa(), s2.targetVa());
-            TestUtils.testClose(s1, s2, singularTs, batchTs[i]);
+            TestUtils.testClose(s1, s2, singularTs, arrayTs);
         }
+        TestUtils.testClose(batchTs);
     }
 
     /**
-     * Verify batch matrix getters (COM transform).
+     * Verify batch matrix getters (COM transform and inverse inertia).
      *
      * @param bi  the interface to use (not null)
      * @param ids IDs of bodies to query (not null)
@@ -230,13 +240,27 @@ public class BodyBatchQueryTest {
      */
     private void verifyMatrixGetters(
             BatchBodyInterface bi, BodyIdArray ids, int n) {
-        DoubleBuffer matBuf = Jolt.newDirectDoubleBuffer(n * 16);
-        bi.getCenterOfMassTransforms(ids, matBuf);
+        // Verify COM Transforms (Real precision)
+        RMat44Array comBuf = new RMat44Array(n);
+        bi.getCenterOfMassTransforms(ids, comBuf);
         for (int i = 0; i < n; ++i) {
-            RMat44 m = bi.getCenterOfMassTransform(ids.get(i));
-            Assert.assertEquals(m.getElement(0, 0), matBuf.get(i * 16), 1e-6);
-            TestUtils.testClose(m);
+            RMat44 singularM = bi.getCenterOfMassTransform(ids.get(i));
+            RMat44 arrayM = comBuf.get(i);
+            Assert.assertTrue(singularM.isEqual(arrayM));
+            TestUtils.testClose(singularM, arrayM);
         }
+        TestUtils.testClose(comBuf);
+
+        // Verify Inverse Inertias (Single precision)
+        Mat44Array inertiaBuf = new Mat44Array(n);
+        bi.getInverseInertias(ids, inertiaBuf);
+        for (int i = 0; i < n; ++i) {
+            Mat44 singularM = bi.getInverseInertia(ids.get(i));
+            Mat44 arrayM = inertiaBuf.get(i);
+            Assert.assertTrue(singularM.isEqual(arrayM));
+            TestUtils.testClose(singularM, arrayM);
+        }
+        TestUtils.testClose(inertiaBuf);
     }
 
     /**


### PR DESCRIPTION
Following our discussion in #38 and the successful merge of #39, this PR completes the planned workflow by switching `BatchBodyInterface` to use the newly added array classes.

Specifically, it updates the interface to utilize `RMat44Array`, `ShapeRefCArray`, and `TransformedShapeArray`. This improves efficiency for batch operations like getting transforms and shapes while providing a cleaner and more consistent API.