### PR TITLE
Fixed an issue where Mat44.setElement did not update the value

### DIFF
--- a/src/main/native/glue/m/Mat44.cpp
+++ b/src/main/native/glue/m/Mat44.cpp
@@ -555,7 +555,7 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_Mat44_setDiagonal3
 JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_Mat44_setElement
   (JNIEnv *, jclass, jlong matrixVa, jint row, jint column, jfloat value) {
     Mat44 * const pMatrix = reinterpret_cast<Mat44 *> (matrixVa);
-    pMatrix->GetColumn4(column)[row] = value;
+    (*pMatrix)(row, column) = value;
 }
 
 /*

--- a/src/main/native/glue/r/RMat44.cpp
+++ b/src/main/native/glue/r/RMat44.cpp
@@ -542,7 +542,9 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_RMat44_setElement
             pMatrix->SetTranslation(copy);
         }
     } else {
-        pMatrix->GetColumn4(column)[row] = value;
+        Vec4 copy = pMatrix->GetColumn4(column);
+        copy[row] = value;
+        pMatrix->SetColumn4(column, copy);
     }
 }
 


### PR DESCRIPTION
There was an issue where changes made to matrix values using setElement in Mat44 were not reflected, so I have fixed it.
The same applies to RMat44.

I confirmed the issue using the following code:
```java
Mat44 mat = new Mat44();
mat.setElement(1, 2, 4f);
System.out.println(mat.getElement(1, 2));

RMat44 rMat = new RMat44();
rMat.setElement(1, 2, 4f);
System.out.println(rMat.getElement(1, 2));
```

> src/main/native/glue/m/Mat44.cpp
` pMatrix->GetColumn4(column)[row] = value; `

I believe the issue stems from updating the vec4 value returned by "GetColumn4" in native code.
Since "GetColumn4" returns a copy of the actual data rather than a reference, updating the return value likely does not change the values in the array within mat44.
I confirmed that it works correctly after making the changes to the code in this PR.