### PR TITLE
Create NativeLibraryLoader.java

### DIFF
--- a/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
+++ b/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
@@ -48,7 +48,7 @@ public final class NativeLibraryLoader {
      * @param libraryPath
      * @return true after successful load, otherwise false
      */
-    public static void loadLibrary(String libraryPath) {
+    public static boolean loadLibrary(String libraryPath) {
         boolean success = false;
 
         try {

--- a/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
+++ b/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024-2026 Stephen Gold
+Copyright (c) 2026 Stephen Gold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
+++ b/src/main/java/com/github/stephengold/joltjni/NativeLibraryLoader.java
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2024-2026 Stephen Gold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.github.stephengold.joltjni;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility class to load native libraries.
+ *
+ * @author David J. Morfe
+ */
+public final class NativeLibraryLoader {
+
+    /**
+     * message logger for this class
+     */
+    final public static Logger logger
+            = Logger.getLogger(NativeLibraryLoader.class.getName());
+
+    /**
+     * A private constructor to inhibit instantiation of this class.
+     */
+    private NativeLibraryLoader() {
+    }
+
+    /**
+     * Load a Jolt native library.
+     *
+     * @param libraryPath
+     * @return true after successful load, otherwise false
+     */
+    public static void loadLibrary(String libraryPath) {
+        boolean success = false;
+
+        try {
+            System.load(libraryPath); // Ensures native library can successfully bind to the native context.
+            logger.info("Jolt DLL loaded");
+            success = true;
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+
+        return success;
+    }
+}


### PR DESCRIPTION
This method can be used to resolve `java.lang.UnsatisfiedLinkError` when used in Minecraft mod development. The intent is to have similar functionality as https://github.com/stephengold/Libbulletjme/blob/master/src/main/java/com/jme3/system/NativeLibraryLoader.java 

In cases where this library is used in modular projects like Minecraft mods, separate `ClassLoader`'s & modules are used to isolate dependency libraries. The JNI native binding in Java is tied to the exact `Class<?>`/module context that owns the native methods.

The issue was that NeoForge, a Minecraft mod development kit (MDK), isolates dependency libraries as separate modules with a `ClassLoader` separate from your main mod project's `ClassLoader`. Calling `System.load(absoluteDLLPath)` directly from within my main mod code resulted in the `java.lang.UnsatisfiedLinkError`.

The solution was to patch the JNI library's jar to call `System.load(absoluteDLLPath)` within that jar so that it's able to successfully bind to that native context.

With this addition, we can guarantee that `System.load()` is executed from the correct JNI ownership context, and binding succeeds.