### PR TITLE
glue:  eliminate ifndef WIN32

### DIFF
--- a/src/main/native/glue/j/JobSystemSingleThreaded.cpp
+++ b/src/main/native/glue/j/JobSystemSingleThreaded.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Stephen Gold
+Copyright (c) 2024-2026 Stephen Gold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -53,8 +53,5 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_JobSystemSingleThread
     JobSystemSingleThreaded * const pSystem
             = reinterpret_cast<JobSystemSingleThreaded *> (systemVa);
     TRACE_DELETE("JobSystemSingleThreaded", pSystem)
-#ifndef WIN32
-    // Attempting to delete a JobSystemSingleThreaded on Windows causes deadlock!
     delete pSystem;
-#endif
 }

--- a/src/main/native/glue/j/JobSystemThreadPool.cpp
+++ b/src/main/native/glue/j/JobSystemThreadPool.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Stephen Gold
+Copyright (c) 2024-2026 Stephen Gold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -52,10 +52,7 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_JobSystemThreadPool_f
   (JNIEnv *, jclass, jlong systemVa) {
     const JobSystem * const pSystem = reinterpret_cast<JobSystem *> (systemVa);
     TRACE_DELETE("JobSystem", pSystem)
-#ifndef WIN32
-    // Attempting to delete a JobSystemThreadPool on Windows causes deadlock!
     delete pSystem;
-#endif
 }
 
 /*

--- a/src/main/native/glue/t/TempAllocatorMalloc.cpp
+++ b/src/main/native/glue/t/TempAllocatorMalloc.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024-2025 Stephen Gold
+Copyright (c) 2024-2026 Stephen Gold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -61,8 +61,5 @@ JNIEXPORT void JNICALL Java_com_github_stephengold_joltjni_TempAllocatorMalloc_f
     const TempAllocatorMalloc * const pAllocator
             = reinterpret_cast<TempAllocatorMalloc *> (allocatorVa);
     TRACE_DELETE("TempAllocatorMalloc", pAllocator)
-#ifndef WIN32
-    // Attempting to delete a TempAllocatorMalloc on Windows causes deadlock!
     delete pAllocator;
-#endif
 }


### PR DESCRIPTION
Initially a workaround for cryptic crashes on Windows platforms, these `#ifndef` s are apparently no longer necessary.